### PR TITLE
add response check to axios error handling

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -18,6 +18,11 @@ export function showError(error) {
 
 export function buildAxiosErrorHandler(onFatal, onDone) {
   return (error) => {
+    if (!error.response) {
+      onFatal();
+      return showError(error);
+    }
+
     if (error.code === errorCodes.ERR_NETWORK) {
       onFatal();
     }


### PR DESCRIPTION
Just added a check in `buildAxiosErrorHandler` that will respond to `net::ERR_CONNECTION_REFUSED` appropriately.